### PR TITLE
fix(lh-83364): upgrade version of cdo connector AMI

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 locals {
-  ami_version = "v0.1.1" # see https://github.com/cisco-lockhart/sec_cookbook
+  ami_version = "a1dc5c0f78915135f94f3ca03cce172f34c96bf5" # see https://jenkins2.dev.lockhart.io/job/Bakery/job/cdo-connector-ami/
 }
 
 data "aws_ami" "sec" {

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ data "aws_ami" "sec" {
     values = ["x86_64"]
   }
 
-  owners = ["692314432491"]
+  owners = ["005087805285"]
 
   most_recent = true
 }


### PR DESCRIPTION
Switch to cdo-connector AMI version running on Cisco hardened Ubuntu.
